### PR TITLE
feat(charts/apps/pod-gateway): upgrade admission controller flags

### DIFF
--- a/charts/apps/pod-gateway/Chart.yaml
+++ b/charts/apps/pod-gateway/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v1.8.1
 description: Admision controller to change the default gateway and DNS server of PODs
 name: pod-gateway
-version: 6.0.0
+version: 6.1.0
 kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway

--- a/charts/apps/pod-gateway/templates/webhook-deployment.yaml
+++ b/charts/apps/pod-gateway/templates/webhook-deployment.yaml
@@ -45,10 +45,16 @@ spec:
             - --DNS={{ .Values.DNS }}
             - --configmapName={{ include "pod-gateway.configmap" . }}
             - --setGatewayLabel={{ .Values.webhook.gatewayLabel }}
+            {{- if .Values.webhook.gatewayLabelValue }}
+            - --setGatewayLabelValue={{ .Values.webhook.gatewayLabelValue }}
+            {{- end }}
             - --setGatewayAnnotation={{ .Values.webhook.gatewayAnnotation }}
-            {{ if .Values.webhook.gatewayDefault }}
+            {{- if .Values.webhook.gatewayAnnotationValue }}
+            - --setGatewayAnnotationValue={{ .Values.webhook.gatewayAnnotationValue }}
+            {{- end }}
+            {{- if .Values.webhook.gatewayDefault }}
             - --setGatewayDefault
-            {{ end }}
+            {{- end }}
             # Static
             - --tls-cert-file-path=/tls/tls.crt
             - --tls-key-file-path=/tls/tls.key

--- a/charts/apps/pod-gateway/values.yaml
+++ b/charts/apps/pod-gateway/values.yaml
@@ -140,6 +140,16 @@ webhook:
   # will get the gateway. If not set setGatewayDefault will apply.
   gatewayLabel: setGateway
 
+  # -- label value to check when evaluating POD. If set, the POD
+  # with the gatewayLabel's value that matches, will get the
+  # gateway. If not set gatewayLabel boolean value will apply.
+  gatewayLabelValue:
+
   # -- annotation name to check when evaluating POD. If true the POD
   # will get the gateway. If not set setGatewayDefault will apply.
   gatewayAnnotation: setGateway
+
+  # -- annotation value to check when evaluating POD. If set, the POD
+  # with gatewayAnnotation'value that matches, will get the gateway.
+  # If not set gatewayAnnotation boolean value will apply.
+  gatewayAnnotationValue:


### PR DESCRIPTION
**Description of the change**

The PR introduces support for the gatewayLabelValue and gatewayAnnotationValue admission controller flags for the pod-gateway Helm chart.

**Benefits**

Thanks to the new https://github.com/angelnu/gateway-admision-controller flags, add support for having multiple [pod-gateway](https://github.com/angelnu/pod-gateway/)s inside a single cluster and allow the end-user, to select for each client application which pod-gateway set as the default gateway for the client application's pods.

**Possible drawbacks**

NA

**Applicable issues**

Closes #48

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
