### PR TITLE
fix(pod-gateway): add NET_RAW capability for dnsmasq #55

### DIFF
--- a/charts/apps/pod-gateway/Chart.yaml
+++ b/charts/apps/pod-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   Admision controller to change the default gateway and DNS server of PODs.
   It is typically used to route PODs through a VPN server.
 name: pod-gateway
-version: 6.1.0
+version: 6.1.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway
@@ -26,7 +26,7 @@ annotations:
   artifacthub.io/changes: |-
     - kind: changed
       description: |
-        Add additional labels
+        Add NET_RAW capabilities to pod-gateway for dnsmasq
       links:
         - name: Common library chart definition
           url: https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/Chart.yaml

--- a/charts/apps/pod-gateway/templates/common.yaml
+++ b/charts/apps/pod-gateway/templates/common.yaml
@@ -10,6 +10,7 @@ command:
 securityContext:
   capabilities:
     add:
+      - NET_RAW
       - NET_ADMIN
 
 # -- Configure persistence settings for the chart under this key.


### PR DESCRIPTION
**Description of the change**

Add NET_RAW capabilities to pod-gateway for dnsmasq

**Applicable issues**

- fixes #55

**Additional information**

N/A

**Checklist**
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
