### PR TITLE
docs: update pod-gateway documentation supporting multiple DNS servers

### DIFF
--- a/charts/apps/pod-gateway/Chart.yaml
+++ b/charts/apps/pod-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   Admision controller to change the default gateway and DNS server of PODs.
   It is typically used to route PODs through a VPN server.
 name: pod-gateway
-version: 6.5.0
+version: 6.5.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway
@@ -30,3 +30,9 @@ annotations:
       links:
         - name: Common library chart definition
           url: https://github.com/bjw-s/helm-charts/blob/main/charts/library/common/Chart.yaml
+    - kind: new
+      description: |
+        Add support for multiple DNS servers
+      links:
+        - name: Gateway Admission Controller PR
+          url: https://github.com/angelnu/gateway-admision-controller/pull/144

--- a/charts/apps/pod-gateway/README.md
+++ b/charts/apps/pod-gateway/README.md
@@ -30,7 +30,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| DNS | string | `"172.16.0.1"` | IP address of the DNS server within the vxlan tunnel. All mutated PODs will get this as their DNS server. It must match VXLAN_GATEWAY_IP in settings.sh |
+| DNS | string | `"172.16.0.1,172.16.0.2"` | Comma-separated IP addresses of the DNS servers within the vxlan tunnel. All mutated PODs will get this as their DNS servers. It must match VXLAN_GATEWAY_IP in settings.sh |
 | DNSPolicy | string | `"None"` | The DNSPolicy to apply to the POD. Only when set to "None" will the DNS value above apply. To avoid altering POD DNS (i.e., to allow initContainers to use DNS before the the VXLAN is up), set to "ClusterFirst" |
 | addons.vpn.enabled | bool | `false` | Enable the VPN if you want to route through a VPN. You might also want to set VPN_BLOCK_OTHER_TRAFFIC to true for extra safeness in case the VPN does connect |
 | addons.vpn.networkPolicy.egress[0].ports[0].port | int | `1194` |  |

--- a/charts/apps/pod-gateway/values.yaml
+++ b/charts/apps/pod-gateway/values.yaml
@@ -14,10 +14,10 @@ image:
   # @default -- chart.appVersion
   tag:
 
-# -- IP address of the DNS server within the vxlan tunnel.
-# All mutated PODs will get this as their DNS server.
+# -- Comma-separated IP addresses of the DNS servers within the vxlan tunnel.
+# All mutated PODs will get this as their DNS servers.
 # It must match VXLAN_GATEWAY_IP in settings.sh
-DNS: 172.16.0.1
+DNS: "172.16.0.1,172.16.0.2"
 
 # -- The DNSPolicy to apply to the POD. Only when set to "None" will the
 # DNS value above apply. To avoid altering POD DNS (i.e., to allow


### PR DESCRIPTION
**Description of the change**

Update the documentation with multiple DNS servers for the `pod-gateway` chart (feature implemented with https://github.com/angelnu/gateway-admision-controller/pull/144).

**Checklist**
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
