### PR TITLE
feat: Add way to configure sidecars as init container in pod-gateway chart

### DIFF
--- a/charts/apps/pod-gateway/Chart.yaml
+++ b/charts/apps/pod-gateway/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   It is typically used to route PODs through a VPN server.
 name: pod-gateway
 version: 6.6.0
-kubeVersion: ">=1.29.0-0"
+kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway
 home: https://github.com/angelnu/charts/tree/master/charts/stable/pod-gateway

--- a/charts/apps/pod-gateway/Chart.yaml
+++ b/charts/apps/pod-gateway/Chart.yaml
@@ -5,8 +5,8 @@ description: |
   Admision controller to change the default gateway and DNS server of PODs.
   It is typically used to route PODs through a VPN server.
 name: pod-gateway
-version: 6.5.1
-kubeVersion: ">=1.16.0-0"
+version: 6.6.0
+kubeVersion: ">=1.29.0-0"
 keywords:
   - pod-gateway
 home: https://github.com/angelnu/charts/tree/master/charts/stable/pod-gateway
@@ -36,3 +36,9 @@ annotations:
       links:
         - name: Gateway Admission Controller PR
           url: https://github.com/angelnu/gateway-admision-controller/pull/144
+    - kind: new
+      description: |
+        Add support for sidecar containers to be created as init container
+      links:
+        - name: Gateway Admission Controller PR
+          url: https://github.com/angelnu/gateway-admision-controller/pull/296

--- a/charts/apps/pod-gateway/README.md
+++ b/charts/apps/pod-gateway/README.md
@@ -61,6 +61,7 @@ Kubernetes: `>=1.16.0-0`
 | webhook.gatewayDefault | bool | `true` | default behviour for new PODs in the evaluated namespace |
 | webhook.gatewayLabel | string | `"setGateway"` | label name to check when evaluating POD. If true the POD will get the gateway. If not set setGatewayDefault will apply. |
 | webhook.gatewayLabelValue | string | `nil` | label value to check when evaluating POD. If set, the POD with the gatewayLabel's value that matches, will get the gateway. If not set gatewayLabel boolean value will apply. |
+| webhook.sidecarAsInit | bool | `false` | determines if the gateway-sidecar container is created as a container or a sidecar container. Requires kubernetes v1.29 <https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/> |
 | webhook.image.pullPolicy | string | `"IfNotPresent"` | image pullPolicy of the webhook |
 | webhook.image.repository | string | `"ghcr.io/angelnu/gateway-admision-controller"` | image repository of the webhook |
 | webhook.image.tag | string | `"v3.10.0"` | image tag of the webhook |

--- a/charts/apps/pod-gateway/templates/webhook-deployment.yaml
+++ b/charts/apps/pod-gateway/templates/webhook-deployment.yaml
@@ -69,6 +69,9 @@ spec:
             - --sidecarImagePullPol={{ .Values.image.pullPolicy }}
             - --sidecarCmd=/bin/client_sidecar.sh
             - --sidecarMountPoint=/config
+            {{- if .Values.webhook.sidecarAsInit }}
+            - --sidecarAsInit
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ include "pod-gateway.webhookPort" . }}

--- a/charts/apps/pod-gateway/values.yaml
+++ b/charts/apps/pod-gateway/values.yaml
@@ -164,3 +164,6 @@ webhook:
   # with gatewayAnnotation'value that matches, will get the gateway.
   # If not set gatewayAnnotation boolean value will apply.
   gatewayAnnotationValue:
+
+  # -- number of webhook instances to deploy
+  sidecarAsInit: false

--- a/charts/apps/pod-gateway/values.yaml
+++ b/charts/apps/pod-gateway/values.yaml
@@ -165,5 +165,5 @@ webhook:
   # If not set gatewayAnnotation boolean value will apply.
   gatewayAnnotationValue:
 
-  # -- number of webhook instances to deploy
+  # -- determines how sidecar container is created
   sidecarAsInit: false


### PR DESCRIPTION
**Description of the change**

Creates sidecar containers as init containers which better support stopping the sidecar when the primary container stops.

**Benefits**

Allow configuring https://github.com/angelnu/gateway-admision-controller/issues/295 via the helm chart


**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [X] Scope of the of the PR title contains the chart name.
- [X] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [X] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [X] Variables have been documented in the `values.yaml` file.
