### PR TITLE
fix(pod-gateway): update default configuration to one single DNS server

### DIFF
--- a/charts/apps/pod-gateway/Chart.yaml
+++ b/charts/apps/pod-gateway/Chart.yaml
@@ -5,7 +5,7 @@ description: |
   Admision controller to change the default gateway and DNS server of PODs.
   It is typically used to route PODs through a VPN server.
 name: pod-gateway
-version: 6.6.0
+version: 6.6.1
 kubeVersion: ">=1.16.0-0"
 keywords:
   - pod-gateway
@@ -42,3 +42,10 @@ annotations:
       links:
         - name: Gateway Admission Controller PR
           url: https://github.com/angelnu/gateway-admision-controller/pull/296
+    - kind: fixed
+      description: |
+        Revert default values to one single DNS server
+      links:
+        - name: Values and Documentation Change PR
+          url: https://github.com/angelnu/helm-charts/pull/187
+

--- a/charts/apps/pod-gateway/README.md
+++ b/charts/apps/pod-gateway/README.md
@@ -30,7 +30,7 @@ Kubernetes: `>=1.16.0-0`
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| DNS | string | `"172.16.0.1,172.16.0.2"` | Comma-separated IP addresses of the DNS servers within the vxlan tunnel. All mutated PODs will get this as their DNS servers. It must match VXLAN_GATEWAY_IP in settings.sh |
+| DNS | string | `"172.16.0.1"` | Comma-separated IP addresses of the DNS servers within the vxlan tunnel. All mutated PODs will get this as their DNS servers. It must match VXLAN_GATEWAY_IP in settings.sh |
 | DNSPolicy | string | `"None"` | The DNSPolicy to apply to the POD. Only when set to "None" will the DNS value above apply. To avoid altering POD DNS (i.e., to allow initContainers to use DNS before the the VXLAN is up), set to "ClusterFirst" |
 | addons.vpn.enabled | bool | `false` | Enable the VPN if you want to route through a VPN. You might also want to set VPN_BLOCK_OTHER_TRAFFIC to true for extra safeness in case the VPN does connect |
 | addons.vpn.networkPolicy.egress[0].ports[0].port | int | `1194` |  |

--- a/charts/apps/pod-gateway/values.yaml
+++ b/charts/apps/pod-gateway/values.yaml
@@ -17,7 +17,7 @@ image:
 # -- Comma-separated IP addresses of the DNS servers within the vxlan tunnel.
 # All mutated PODs will get this as their DNS servers.
 # It must match VXLAN_GATEWAY_IP in settings.sh
-DNS: "172.16.0.1,172.16.0.2"
+DNS: 172.16.0.1
 
 # -- The DNSPolicy to apply to the POD. Only when set to "None" will the
 # DNS value above apply. To avoid altering POD DNS (i.e., to allow


### PR DESCRIPTION
<!--
Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- Describe the scope of your change - i.e. what the change does.
- Describe any known limitations with your change.
- Please run any tests or examples that can exercise your modified code.

Thank you for contributing! I will try to test and integrate the change as soon as I can. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

Also don't be worried if the request is closed or not integrated. Sometimes our priorities might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
-->

**Description of the change**

While https://github.com/angelnu/gateway-admision-controller/pull/144 added the _ability_ to use multiple DNS servers, the chart still provisions only one single gateway and hence one single server IP.

Therefore, this PR partially reverts #70 to align with the rest of the chart.

**Benefits**

Without this change, any user using the default values.yaml will get DNS errors like `cannot reach 172.16.0.2` half of the time, since two DNS servers are specified yet only one is actually present. The user will have to dig deep into the networking before they'll realize what is actually going on, and either override the `DNS` value or provision another DNS server.

But once this PR merges, DNS works again out of the box. And most common setup will only need one server anyway. Users can still change the `DNS` value if they have a non-default setup.

**Possible drawbacks**

If we merge this PR and change the default value back, users will have slightly lesser chances discovering the fact that multiple DNS servers are possible. I think this is acceptable since the description column still describes it as a comma-separated list (introduced in #70, not being reverted here). They will still look into how to change the `DNS` value and find the description. And multiple DNS servers are less common anyway.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
