### PR TITLE
fix(multus) operation not permitted on k3s

### DIFF
--- a/charts/apps/multus/templates/common.yaml
+++ b/charts/apps/multus/templates/common.yaml
@@ -25,7 +25,7 @@ controllers:
         - /usr/src/multus-cni/bin/multus-daemon
         # -- Need to run as privileged to install
         securityContext:
-          allowPrivilegeEscalation: false
+          privileged: true
           readOnlyRootFilesystem: true
           capabilities:
             add:
@@ -49,6 +49,8 @@ controllers:
           - "-f"
           - "/usr/src/multus-cni/bin/multus-shim"
           - "/host/opt/cni/bin/multus-shim"
+        securityContext:
+          privileged: true
         resources:
           requests:
             cpu: "10m"


### PR DESCRIPTION
**Description of the change**
See issue #231 

This allows privileged operation on for the main and install containers.
**Benefits**

<!-- What benefits will be realized by the code change? -->

**Possible drawbacks**

I don't understand why the privileges were reduced in this helm chart given the example deployment [thick deployment](https://github.com/k8snetworkplumbingwg/multus-cni/blob/master/deployments/multus-daemonset-thick.yml) seems to run as privileged.

**Applicable issues**

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #231 

**Additional information**

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [ ] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [ ] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [ ] Variables have been documented in the `values.yaml` file.
