### PR TITLE
fix: correct indentation of the annotation for DNSMadeEasy

### DIFF
--- a/charts/apps/dnsmadeeasy-webhook/Chart.yaml
+++ b/charts/apps/dnsmadeeasy-webhook/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 appVersion: v1.9.0 # renovate: depName=ghcr.io/angelnu/dnsmadeeasy-webhook datasource=docker
 description: Cert-Manager Webhook for DNSMadeEasy
 name: dnsmadeeasy-webhook
-version: 6.0.1
+version: 6.0.2
 keywords:
   - cert-manager
   - dnsmadeeasy

--- a/charts/apps/dnsmadeeasy-webhook/templates/common.yaml
+++ b/charts/apps/dnsmadeeasy-webhook/templates/common.yaml
@@ -70,8 +70,8 @@ rawResources:
       kind: APIService
       metadata:
          name: v1alpha1.{{ .Values.groupName }}
-      annotations:
-        certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "dnsmadeeasy-webhook.servingcertificate" . }}"
+         annotations:
+            certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "dnsmadeeasy-webhook.servingcertificate" . }}"
       spec:
         group: {{ .Values.groupName }}
         groupPriorityMinimum: 1000


### PR DESCRIPTION
**Description of the change**

A very simple indentation correction that was causing errors when installing the chart.

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [x] Title of the PR conforms to the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] Scope of the of the PR title contains the chart name.
- [x] Chart version in `Chart.yaml` has been bumped according to [Semantic Versioning](https://semver.org/).
- [x] Chart `artifacthub.io/changes` changelog annotation has been updated in `Chart.yaml`. See [Artifact Hub documentation](https://artifacthub.io/docs/topics/annotations/helm/#supported-annotations) for more info.
- [x] Variables have been documented in the `values.yaml` file.
